### PR TITLE
[DEV] Fixed ghost moveable game objects

### DIFF
--- a/src/game/managers/MovementManager.py
+++ b/src/game/managers/MovementManager.py
@@ -1,9 +1,11 @@
 from game.interfaces.IMoveable import IMovable
+from game.interfaces.IObserveable import IObserveable
+from game.abstracts.IObserver import IObserver
 
 from game.managers.InteractionManager import InteractionManager
 
 
-class MovementManager:
+class MovementManager(IObserver):
     def __init__(self, game_world):
         self.game_world = game_world
         self.interaction_manager = InteractionManager(game_world)
@@ -12,8 +14,18 @@ class MovementManager:
     def register_movable_objects(self):
         for row in self.game_world.map:
             for tile in row:
-                if not tile.is_empty() and isinstance(tile.game_object, IMovable):
-                    self.movable_objects.append(tile.game_object)
+                if not tile.is_empty():
+                    self.add_moveable_object(tile.game_object)
+
+    def add_moveable_object(self, moveable_object):
+        if isinstance(moveable_object, IMovable):
+            self.movable_objects.append(moveable_object)
+            if isinstance(moveable_object, IObserveable):
+                moveable_object.register(self)
+
+    def remove_moveable_object(self, moveable_object):
+        if moveable_object in self.movable_objects:
+            self.movable_objects.remove(moveable_object)
 
     def move_objects(self, direction):
         for movable_object in self.movable_objects:
@@ -68,3 +80,7 @@ class MovementManager:
     def is_position_walkable(self, position):
         row, col = position
         return self.game_world.map[row][col].is_walkable
+
+    def update(self, moveable_object):
+        if moveable_object in self.movable_objects:
+            self.remove_moveable_object(moveable_object)

--- a/src/game/managers/MovementManager.py
+++ b/src/game/managers/MovementManager.py
@@ -1,6 +1,6 @@
 from game.interfaces.IMoveable import IMovable
 from game.interfaces.IObserveable import IObserveable
-from game.abstracts.IObserver import IObserver
+from game.interfaces.IObserver import IObserver
 
 from game.managers.InteractionManager import InteractionManager
 


### PR DESCRIPTION
## Description

This pull request aims to fix a bug where moveable objects were not removed from the `MovementManager` list. This caused it to not be properly removed from the list when destroyed. This meant that the moveable objects could still be moved despite being destroyed.

## Changes

- Fixed ghost hover box visual bug
- Dependencies added: _None_

## Related Issues

- #10 

## Screenshots (if applicable)

<img width="912" alt="Screenshot 2024-03-26 at 15 13 31" src="https://github.com/PrometheusBork/AI-RTS-PROJECT/assets/43484432/79541488-47a0-4f21-a613-07f9b4d7958f">

<img width="912" alt="Screenshot 2024-03-26 at 15 15 28" src="https://github.com/PrometheusBork/AI-RTS-PROJECT/assets/43484432/9b7d8c34-1ceb-4f63-9f65-4492111838b9">

## Notes for Reviewers
__This pull request is blocked by #11 